### PR TITLE
Feat : Atom => Button , PublicRouter

### DIFF
--- a/Client/src/App.tsx
+++ b/Client/src/App.tsx
@@ -25,16 +25,18 @@ import {
   MediumButtonType,
   LargeButtonType,
 } from "@Constant/.";
+import { sayHello } from "@Util/.";
 
 const App = () => {
-  const type = {
-    width: 100,
-    height: 200,
-  };
+  const handleMediumButtonClick = () => console.log(sayHello());
   return (
     <Suspense fallback={<Spin />}>
       <Button {...SmallButtonType} title={"hihi"} />
-      <Button {...MediumButtonType} title="컴포넌트 확장" />
+      <Button
+        {...MediumButtonType}
+        title="컴포넌트 확장"
+        onClick={handleMediumButtonClick}
+      />
       <Button {...LargeButtonType} />
       <Switch>
         <PublicRoute path="/" component={Page} exact />

--- a/Client/src/App.tsx
+++ b/Client/src/App.tsx
@@ -1,34 +1,60 @@
 import { Suspense } from "react";
-import { Oval } from "react-loader-spinner";
 import { Route, Switch } from "react-router-dom";
 
+import Page from "@Pages/.";
 import AdminPage from "@Pages/Admin";
 import BoardPage from "@Pages/Board";
 import ErrorPage from "@Pages/Error";
 import LoginPage from "@Pages/Login";
 import MainPage from "@Pages/Main";
 import MyPage from "@Pages/MyPage";
+import NoticePage from "@Pages/Notice";
+import ProjectPage from "@Pages/Project";
+import StudyPage from "@Pages/Study";
+import ReservePage from "@Pages/Reserve";
+import RankingPage from "@Pages/Ranking";
 
-import Header from "@Organisms/Header";
-
+import PublicRoute from "@Route/PublicRoute";
 import PrivateRoute from "@Route/PrivateRoute";
 import AdminRoute from "@Route/AdminRoute";
 
+import Button from "@Atoms/Button";
+import Spin from "@Atoms/Spinner";
+import {
+  SmallButtonType,
+  MediumButtonType,
+  LargeButtonType,
+} from "@Constant/.";
+
 const App = () => {
+  const type = {
+    width: 100,
+    height: 200,
+  };
   return (
-    <>
-      <Header />
-      <Suspense fallback={<Oval color="blue" width={100} height={100} />}>
-        <Switch>
-          <Route path="/" component={MainPage} exact />
-          <Route path="/board" component={BoardPage} exact />
-          <Route path="/login" component={LoginPage} exact />
-          <PrivateRoute path="/mypage" component={MyPage} />
-          <AdminRoute path="/admin" component={AdminPage} />
-          <Route path="/error" component={ErrorPage} />
-        </Switch>
-      </Suspense>
-    </>
+    <Suspense fallback={<Spin />}>
+      <Button {...SmallButtonType} title={"hihi"} />
+      <Button {...MediumButtonType} title="컴포넌트 확장" />
+      <Button {...LargeButtonType} />
+      <Switch>
+        <PublicRoute path="/" component={Page} exact />
+        <PublicRoute path="/login" component={LoginPage} exact />
+
+        <PrivateRoute path="/main" component={MainPage} exact />
+        <PrivateRoute path="/board" component={BoardPage} exact />
+        <PrivateRoute path="/notice" component={NoticePage} exact />
+
+        <PrivateRoute path="/project" component={ProjectPage} exact />
+        <PrivateRoute path="/study" component={StudyPage} exact />
+
+        <PrivateRoute path="/mypage" component={MyPage} exact />
+        <PrivateRoute path="/reserve" component={ReservePage} exact />
+        <PrivateRoute path="/rank" component={RankingPage} exact />
+
+        <AdminRoute path="/admin" component={AdminPage} />
+        <Route path="*" component={ErrorPage} exact />
+      </Switch>
+    </Suspense>
   );
 };
 

--- a/Client/src/Common/Constant/index.ts
+++ b/Client/src/Common/Constant/index.ts
@@ -5,22 +5,22 @@ export const API_GET_OPTION = {
 // 버튼
 
 export const SmallButtonType = {
-  width: 150,
-  height: 50,
+  width: "150px",
+  height: "50px",
   borderColor: "#000000",
   backGroundColor: "#ffffff",
 };
 
 export const MediumButtonType = {
-  width: 200,
-  height: 100,
+  width: "200px",
+  height: "100px",
   borderColor: "#000000",
   backGroundColor: "#ffffff",
 };
 
 export const LargeButtonType = {
-  width: 300,
-  height: 150,
+  width: "300px",
+  height: "150px",
   borderColor: "#000000",
   backGroundColor: "#ffffff",
 };

--- a/Client/src/Common/Constant/index.ts
+++ b/Client/src/Common/Constant/index.ts
@@ -1,3 +1,26 @@
 export const API_GET_OPTION = {
   withCredentials: true,
 };
+
+// 버튼
+
+export const SmallButtonType = {
+  width: 150,
+  height: 50,
+  borderColor: "#000000",
+  backGroundColor: "#ffffff",
+};
+
+export const MediumButtonType = {
+  width: 200,
+  height: 100,
+  borderColor: "#000000",
+  backGroundColor: "#ffffff",
+};
+
+export const LargeButtonType = {
+  width: 300,
+  height: 150,
+  borderColor: "#000000",
+  backGroundColor: "#ffffff",
+};

--- a/Client/src/Components/Atoms/Button/index.tsx
+++ b/Client/src/Components/Atoms/Button/index.tsx
@@ -1,0 +1,37 @@
+import ButtonContainer from "./styles";
+
+export interface Props {
+  width?: number;
+  height?: number;
+  borderColor?: string;
+  backGroundColor?: string;
+  title?: string;
+}
+
+const Button = ({
+  width,
+  height,
+  borderColor,
+  backGroundColor,
+  title,
+}: Props) => {
+  return (
+    <ButtonContainer
+      width={width}
+      height={height}
+      borderColor={borderColor}
+      backGroundColor={backGroundColor}
+    >
+      {title}
+    </ButtonContainer>
+  );
+};
+
+Button.defaultProps = {
+  width: 150,
+  height: 50,
+  borderColor: "#000000",
+  backGroundColor: "#ffffff",
+  title: "Click !",
+};
+export default Button;

--- a/Client/src/Components/Atoms/Button/index.tsx
+++ b/Client/src/Components/Atoms/Button/index.tsx
@@ -1,11 +1,12 @@
 import ButtonContainer from "./styles";
 
 export interface Props {
-  width?: number;
-  height?: number;
+  width?: string;
+  height?: string;
   borderColor?: string;
   backGroundColor?: string;
   title?: string;
+  onClick?: () => void;
 }
 
 const Button = ({
@@ -14,6 +15,7 @@ const Button = ({
   borderColor,
   backGroundColor,
   title,
+  onClick,
 }: Props) => {
   return (
     <ButtonContainer
@@ -21,6 +23,7 @@ const Button = ({
       height={height}
       borderColor={borderColor}
       backGroundColor={backGroundColor}
+      onClick={onClick}
     >
       {title}
     </ButtonContainer>

--- a/Client/src/Components/Atoms/Button/styles.tsx
+++ b/Client/src/Components/Atoms/Button/styles.tsx
@@ -1,9 +1,9 @@
 import styled from "styled-components";
 import { Props } from ".";
 
-const ButtonContainer = styled.div<Props>`
-  width: ${({ width }) => width}px;
-  height: ${({ height }) => height}px;
+const ButtonContainer = styled.button<Props>`
+  width: ${({ width }) => width};
+  height: ${({ height }) => height};
   border: 1px solid ${({ borderColor }) => borderColor};
   border-radius: 10px;
   display: flex;

--- a/Client/src/Components/Atoms/Button/styles.tsx
+++ b/Client/src/Components/Atoms/Button/styles.tsx
@@ -1,0 +1,16 @@
+import styled from "styled-components";
+import { Props } from ".";
+
+const ButtonContainer = styled.div<Props>`
+  width: ${({ width }) => width}px;
+  height: ${({ height }) => height}px;
+  border: 1px solid ${({ borderColor }) => borderColor};
+  border-radius: 10px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: ${({ backGroundColor }) => backGroundColor};
+  cursor: pointer;
+`;
+
+export default ButtonContainer;

--- a/Client/src/Components/Atoms/Spinner/index.tsx
+++ b/Client/src/Components/Atoms/Spinner/index.tsx
@@ -1,0 +1,12 @@
+import Spinner from "./styles";
+import { Oval } from "react-loader-spinner";
+
+const Spin = () => {
+  return (
+    <Spinner>
+      <Oval color="blue" width={100} height={100} />
+    </Spinner>
+  );
+};
+
+export default Spin;

--- a/Client/src/Components/Atoms/Spinner/styles.tsx
+++ b/Client/src/Components/Atoms/Spinner/styles.tsx
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+
+const Spinner = styled.div`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+`;
+
+export default Spinner;

--- a/Client/src/Components/Pages/Notice.tsx
+++ b/Client/src/Components/Pages/Notice.tsx
@@ -1,0 +1,5 @@
+const NoticePage = () => {
+  return <div>공지사항 페이지</div>;
+};
+
+export default NoticePage;

--- a/Client/src/Components/Pages/Project.tsx
+++ b/Client/src/Components/Pages/Project.tsx
@@ -1,0 +1,5 @@
+const ProjectPage = () => {
+  return <div>프로젝트 관련 페이지</div>;
+};
+
+export default ProjectPage;

--- a/Client/src/Components/Pages/Ranking.tsx
+++ b/Client/src/Components/Pages/Ranking.tsx
@@ -1,0 +1,5 @@
+const RankingPage = () => {
+  return <div>백준 랭킹</div>;
+};
+
+export default RankingPage;

--- a/Client/src/Components/Pages/Reserve.tsx
+++ b/Client/src/Components/Pages/Reserve.tsx
@@ -1,0 +1,5 @@
+const ReservePage = () => {
+  return <div>과방 예약</div>;
+};
+
+export default ReservePage;

--- a/Client/src/Components/Pages/Study.tsx
+++ b/Client/src/Components/Pages/Study.tsx
@@ -1,0 +1,5 @@
+const StudyPage = () => {
+  return <div>스터디 페이지입니다.</div>;
+};
+
+export default StudyPage;

--- a/Client/src/Components/Pages/index.tsx
+++ b/Client/src/Components/Pages/index.tsx
@@ -1,0 +1,5 @@
+const Page = () => {
+  return <div>로그인 전 페이지</div>;
+};
+
+export default Page;

--- a/Client/src/Routes/PublicRoute.tsx
+++ b/Client/src/Routes/PublicRoute.tsx
@@ -8,20 +8,20 @@ interface Props {
   exact: boolean;
 }
 
-const PrivateRoute = ({
+const PublicRoute = ({
   component: Component,
   path,
   exact,
 }: Props): JSX.Element => {
   const user = useRecoilValue(checkLoginSelector);
-
+  console.log(user);
   return (
     <Route
       exact={exact}
       path={path}
-      render={() => (user ? <Component /> : <Redirect to="/login" />)}
+      render={() => (user ? <Redirect to="/main" /> : <Component />)}
     />
   );
 };
 
-export default PrivateRoute;
+export default PublicRoute;


### PR DESCRIPTION
[ 진행 작업 ]
- Button 확장 고려 Atom Component 생성
- PublicRouter 생성

[ 문제 사항 ]
- Button 확장 고려하여 Component 생성하는데 있어서 많은 고민 발생, 이전에는 type을 설정해서 medium,large,small을 비교했었음.
- PublicRouter생성 뿐만아닌 커스텀 Router에서 exact 사용 에러 발생

[ 해결 방법 ]
- Button의 Props로 type을 설정이 아닌 width, height, color 와 같은 Props를 추가해주어 버튼의 확장성을 높였다. 뿐만아니라, 상수로 커스텀 button type을 구현하여 smallButtonType을 export해서 사용할 수 있게 하였다.
- 커스텀 Router 에서 Props로 exact:boolean 설정을 해주어서 사용하였다.