### PR TITLE
[ Feat ] 공지사항 게시판, 자유게시판 구현

### DIFF
--- a/Client/public/dummyData/FreeBoardContent.json
+++ b/Client/public/dummyData/FreeBoardContent.json
@@ -1,228 +1,205 @@
 {
-    "res": [{
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        }
-    ],
-    "status": 200
+  "res": [
+    {
+      "idx": 1,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 1",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 2,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 2",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 3,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 3",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 4,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 4",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 5,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 5",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 6,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 6",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 7,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 7",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 8,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 8",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 9,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 9",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 10,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 10",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 11,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 11",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 12,
+      "board": "notice",
+      "title": "김영진은 무엇인가?12 ",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 13,
+      "board": "notice",
+      "title": "김영진은 무엇인가?13 ",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 14,
+      "board": "notice",
+      "title": "김영진은 무엇인가?14 ",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 15,
+      "board": "notice",
+      "title": "김영진은 무엇인가?15 ",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 16,
+      "board": "notice",
+      "title": "김영진은 무엇인가?16 ",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 17,
+      "board": "notice",
+      "title": "김영진은 무엇인가?17 ",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 18,
+      "board": "notice",
+      "title": "김영진은 무엇인가?18 ",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 19,
+      "board": "notice",
+      "title": "김영진은 무엇인가?19 ",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 20,
+      "board": "notice",
+      "title": "김영진은 무엇인가?20 ",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    }
+  ],
+  "status": 200
 }

--- a/Client/public/dummyData/NoticeBoardContent.json
+++ b/Client/public/dummyData/NoticeBoardContent.json
@@ -1,92 +1,405 @@
 {
-    "res": [{
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        },
-        {
-            "board": "notice",
-            "title": "김영진은 무엇인가? ",
-            "text": "갓일수도 있음",
-            "date": "2022-02-10",
-            "images": [],
-            "writer": "Hong Han Sol"
-        }
-    ],
-    "status": 200
+  "res": [
+    {
+      "idx": 1,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 1",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 2,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 2",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 3,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 3",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 4,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 4",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 5,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 5",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 6,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 6",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 7,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 7",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 8,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 8",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 9,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 9",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 10,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 10",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 11,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 11",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 12,
+      "board": "notice",
+      "title": "김영진은 무엇인가?12 ",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 13,
+      "board": "notice",
+      "title": "김영진은 무엇인가?13 ",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 14,
+      "board": "notice",
+      "title": "김영진은 무엇인가?14 ",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 15,
+      "board": "notice",
+      "title": "김영진은 무엇인가?15 ",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 16,
+      "board": "notice",
+      "title": "김영진은 무엇인가?16 ",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 17,
+      "board": "notice",
+      "title": "김영진은 무엇인가?17 ",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 18,
+      "board": "notice",
+      "title": "김영진은 무엇인가?18 ",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 19,
+      "board": "notice",
+      "title": "김영진은 무엇인가?19 ",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 20,
+      "board": "notice",
+      "title": "김영진은 무엇인가?20 ",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 21,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 1",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 22,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 2",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 23,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 3",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 24,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 4",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 25,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 5",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 26,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 6",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 27,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 7",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 28,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 8",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 29,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 9",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 30,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 10",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 31,
+      "board": "notice",
+      "title": "김영진은 무엇인가? 11",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 32,
+      "board": "notice",
+      "title": "김영진은 무엇인가?12 ",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 33,
+      "board": "notice",
+      "title": "김영진은 무엇인가?13 ",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 34,
+      "board": "notice",
+      "title": "김영진은 무엇인가?14 ",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 35,
+      "board": "notice",
+      "title": "김영진은 무엇인가?15 ",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 36,
+      "board": "notice",
+      "title": "김영진은 무엇인가?16 ",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 37,
+      "board": "notice",
+      "title": "김영진은 무엇인가?17 ",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 38,
+      "board": "notice",
+      "title": "김영진은 무엇인가?18 ",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 39,
+      "board": "notice",
+      "title": "김영진은 무엇인가?19 ",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    },
+    {
+      "idx": 40,
+      "board": "notice",
+      "title": "김영진은 무엇인가?20 ",
+      "text": "갓일수도 있음",
+      "date": "2022-02-10",
+      "images": [],
+      "writer": "Hong Han Sol",
+      "visitor": 20
+    }
+  ],
+  "status": 200
 }

--- a/Client/src/App.tsx
+++ b/Client/src/App.tsx
@@ -33,7 +33,9 @@ const App = () => {
 
         <PrivateRoute path="/main" component={MainPage} exact />
         <PrivateRoute path="/board" component={BoardPage} exact />
+        <PrivateRoute path="/board/:id" component={BoardPage} exact />
         <PrivateRoute path="/notice" component={NoticePage} exact />
+        <PrivateRoute path="/notice/:id" component={NoticePage} exact />
 
         <PrivateRoute path="/project" component={ProjectPage} exact />
         <PrivateRoute path="/study" component={StudyPage} exact />

--- a/Client/src/Common/Type/index.ts
+++ b/Client/src/Common/Type/index.ts
@@ -74,6 +74,8 @@ export interface BoardContentType {
   date: string;
   images: string[];
   writer: string;
+  visitor: number;
+  idx: number;
 }
 
 export interface StudyContentType {
@@ -83,6 +85,7 @@ export interface StudyContentType {
   leaderUserIdx: number;
   leaderName: string;
   status: string;
+  idx: number;
 }
 
 export interface ProjectContentType extends StudyContentType {
@@ -93,11 +96,13 @@ export interface RankingContentType {
   rating: number;
   tier: string;
   name: string;
+  idx: number;
 }
 
 export interface PreviewProps {
   previewType?: string;
   content: ContentType;
+  type?: string;
 }
 
 export type ContentType =

--- a/Client/src/Components/Molecules/BoardPage/Footer/index.tsx
+++ b/Client/src/Components/Molecules/BoardPage/Footer/index.tsx
@@ -1,0 +1,55 @@
+import React, { Dispatch, SetStateAction, useMemo } from "react";
+import { BoardFooterContainer, BoardFooterItem } from "./styles";
+
+const FOOTER_LIST_LENGTH = 5;
+
+const Footer = ({
+  noticePageNum,
+  setNoticePageNum,
+  totalBoardContentLength,
+}: {
+  noticePageNum: number;
+  setNoticePageNum: Dispatch<SetStateAction<number>>;
+  totalBoardContentLength: number;
+}) => {
+  const handleButtonClick = (e: any) => {
+    //   const handleButtonClick = (e: React.MouseEvent<HTMLElement>) => {
+    const target = e?.target?.closest("#target");
+    if (!target) return;
+    setNoticePageNum(Number(target.getAttribute("data-idx")) - 1);
+  };
+
+  const totalList = useMemo(() => {
+    return new Array(totalBoardContentLength).fill(1).map((_, idx) => idx);
+  }, [totalBoardContentLength]);
+
+  const arrList =
+    noticePageNum < FOOTER_LIST_LENGTH
+      ? totalList.filter((item) => item < 2 * FOOTER_LIST_LENGTH)
+      : noticePageNum > totalBoardContentLength - FOOTER_LIST_LENGTH
+      ? totalList.filter(
+          (item) => item > totalBoardContentLength - 2 * FOOTER_LIST_LENGTH
+        )
+      : totalList.filter(
+          (item) =>
+            noticePageNum - FOOTER_LIST_LENGTH < Number(item) &&
+            Number(item) < noticePageNum + FOOTER_LIST_LENGTH
+        );
+
+  return (
+    <BoardFooterContainer onClick={handleButtonClick}>
+      {arrList.map((item, idx) => (
+        <BoardFooterItem
+          key={item}
+          id="target"
+          data-idx={Number(item) + 1}
+          style={{ color: item === noticePageNum ? "#d3d1d1" : "" }}
+        >
+          {item + 1}
+        </BoardFooterItem>
+      ))}
+    </BoardFooterContainer>
+  );
+};
+
+export default Footer;

--- a/Client/src/Components/Molecules/BoardPage/Footer/styles.tsx
+++ b/Client/src/Components/Molecules/BoardPage/Footer/styles.tsx
@@ -1,0 +1,19 @@
+import styled from "styled-components";
+
+const BoardFooterContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const BoardFooterItem = styled.div`
+  color: #707070;
+  cursor: pointer;
+  padding: 30px;
+  padding-left: 0;
+  &:hover {
+    color: #d3d1d1;
+  }
+`;
+
+export { BoardFooterContainer, BoardFooterItem };

--- a/Client/src/Components/Molecules/BoardPage/List/index.tsx
+++ b/Client/src/Components/Molecules/BoardPage/List/index.tsx
@@ -1,0 +1,66 @@
+import { _BOARD_INFOS } from "@Constant/.";
+import { ContentContainer } from "@Organisms/Main/BoardContent/style";
+import {
+  BoardContentPagenationSelector,
+  BoardContentSelector,
+  GetBoardContentLengthSelector,
+} from "@Recoil/BoardContent";
+import { ContentType } from "@Type/.";
+import { hasBoardContent } from "@Util/.";
+import { Suspense, useState } from "react";
+import { useRecoilValue } from "recoil";
+import BoardPreview from "@Molecules/BoardPreview";
+import { BoardContainer } from "./styles";
+import Footer from "../Footer";
+
+const BoardList = ({ type }: { type: string }) => {
+  const { apiSrc, previewType, alignPreview = "column;" } = _BOARD_INFOS[type];
+  const [noticePageNum, setNoticePageNum] = useState<number>(0);
+
+  const totalContents =
+    (hasBoardContent(apiSrc, type) &&
+      useRecoilValue<ContentType[]>(
+        BoardContentPagenationSelector([noticePageNum, apiSrc])
+      )) ??
+    [];
+  // const boardContents =
+  //   hasBoardContent(apiSrc, type) &&
+  //   useRecoilValue<ContentType[]>(
+  //     BoardContentPagenationSelector([noticePageNum, apiSrc])
+  //   );
+
+  const boardContents = totalContents.filter(
+    (item) =>
+      item.idx > noticePageNum * 10 && item.idx <= (noticePageNum + 1) * 10
+  );
+
+  const totalBoardContentLength =
+    (hasBoardContent(apiSrc, type) &&
+      useRecoilValue<number>(GetBoardContentLengthSelector(apiSrc))) ??
+    1;
+
+  return (
+    <>
+      <Suspense fallback={null}>
+        <ContentContainer alignPreview={alignPreview}>
+          {boardContents?.map((content) => (
+            <BoardContainer key={content.idx}>
+              <BoardPreview
+                previewType={previewType}
+                content={content}
+                type="게시판"
+              />
+            </BoardContainer>
+          ))}
+          <Footer
+            noticePageNum={noticePageNum}
+            setNoticePageNum={setNoticePageNum}
+            totalBoardContentLength={totalBoardContentLength}
+          />
+        </ContentContainer>
+      </Suspense>
+    </>
+  );
+};
+
+export default BoardList;

--- a/Client/src/Components/Molecules/BoardPage/List/index.tsx
+++ b/Client/src/Components/Molecules/BoardPage/List/index.tsx
@@ -12,10 +12,12 @@ import { useRecoilValue } from "recoil";
 import BoardPreview from "@Molecules/BoardPreview";
 import { BoardContainer } from "./styles";
 import Footer from "../Footer";
+import { useHistory } from "react-router-dom";
 
 const BoardList = ({ type }: { type: string }) => {
   const { apiSrc, previewType, alignPreview = "column;" } = _BOARD_INFOS[type];
   const [noticePageNum, setNoticePageNum] = useState<number>(0);
+  const history = useHistory();
 
   const totalContents =
     (hasBoardContent(apiSrc, type) &&
@@ -39,12 +41,27 @@ const BoardList = ({ type }: { type: string }) => {
       useRecoilValue<number>(GetBoardContentLengthSelector(apiSrc))) ??
     1;
 
+  const handleNoticeDetailMove = (e: any) => {
+    const target = e.target.closest("#boardContainer");
+    if (!target) return;
+    const idx = target.getAttribute("data-idx");
+    const path = type === "공지사항" ? "notice" : "board";
+    history.push(`/${path}/${idx}`);
+  };
+
   return (
     <>
       <Suspense fallback={null}>
-        <ContentContainer alignPreview={alignPreview}>
+        <ContentContainer
+          alignPreview={alignPreview}
+          onClick={handleNoticeDetailMove}
+        >
           {boardContents?.map((content) => (
-            <BoardContainer key={content.idx}>
+            <BoardContainer
+              key={content.idx}
+              data-idx={content.idx}
+              id="boardContainer"
+            >
               <BoardPreview
                 previewType={previewType}
                 content={content}

--- a/Client/src/Components/Molecules/BoardPage/List/styles.tsx
+++ b/Client/src/Components/Molecules/BoardPage/List/styles.tsx
@@ -1,0 +1,15 @@
+import styled from "styled-components";
+
+const BoardContainer = styled.div`
+  padding: 20px 0;
+  width: 70%;
+  margin: auto;
+  cursor: pointer;
+  &:hover {
+    border-radius: 12px;
+    border: 1px solid #b3b0b0;
+    background-color: #ffffff;
+  }
+`;
+
+export { BoardContainer };

--- a/Client/src/Components/Molecules/BoardPreview/Basic/index.tsx
+++ b/Client/src/Components/Molecules/BoardPreview/Basic/index.tsx
@@ -1,11 +1,31 @@
-import { Container, Text } from "./style";
+import { Container, Text, Date } from "./style";
 import { BoardContentType } from "@Type/.";
 
-const BasicBoardPreview = ({ title, date }: BoardContentType) => {
+interface BasicBoardPreviewProps extends BoardContentType {
+  type: string;
+  idx: number;
+}
+const BasicBoardPreview = ({
+  title,
+  date,
+  type,
+  visitor,
+  idx,
+}: BasicBoardPreviewProps) => {
+  const enumText = type !== "basic" ? idx : "•";
   return (
     <Container>
-      <Text>{`• ${title}`}</Text>
-      <Text>{date}</Text>
+      <Text>
+        <span>{enumText}</span>
+        {title}
+      </Text>
+      <Date>{date}</Date>
+      {type !== "basic" && (
+        <>
+          <Text>조회수</Text>
+          <Text>{visitor}</Text>
+        </>
+      )}
     </Container>
   );
 };

--- a/Client/src/Components/Molecules/BoardPreview/Basic/style.tsx
+++ b/Client/src/Components/Molecules/BoardPreview/Basic/style.tsx
@@ -1,12 +1,25 @@
 import { AlignCenterBetween } from "@Style/.";
 import styled from "styled-components";
 
-export const Container = styled.div`
+const Container = styled.div`
   display: flex;
   height: 15%;
   ${AlignCenterBetween};
+  padding: 12px 17px;
+  box-sizing: border;
+  cursor: pointer;
 `;
 
-export const Text = styled.p`
+const Text = styled.p`
   font-size: 0.8rem;
+  span {
+    margin-right: 27px;
+  }
 `;
+
+const Date = styled(Text)`
+  width: 50%;
+  text-align: right;
+`;
+
+export { Container, Text, Date };

--- a/Client/src/Components/Molecules/BoardPreview/index.tsx
+++ b/Client/src/Components/Molecules/BoardPreview/index.tsx
@@ -10,7 +10,11 @@ import CardPreviewImage from "./Card/.";
 import ImageBoardPreview from "./Image/.";
 import RankingBoardPreview from "./Ranking/.";
 
-const BoardPreview = ({ content, previewType = "basic" }: PreviewProps) => {
+const BoardPreview = ({
+  content,
+  previewType = "basic",
+  type = "basic",
+}: PreviewProps) => {
   const getPreview = (previewType: string): JSX.Element => {
     if (previewType === "card")
       return <CardPreviewImage {...convertProjectType(content)} />;
@@ -22,7 +26,7 @@ const BoardPreview = ({ content, previewType = "basic" }: PreviewProps) => {
     if (previewType === "calendar") {
       return <Calendar />;
     }
-    return <BasicBoardPreview {...convertBoardType(content)} />;
+    return <BasicBoardPreview {...convertBoardType(content)} type={type} />;
   };
 
   return getPreview(previewType);

--- a/Client/src/Components/Organisms/BoardBody/index.tsx
+++ b/Client/src/Components/Organisms/BoardBody/index.tsx
@@ -1,0 +1,15 @@
+import BoardList from "../../Molecules/BoardPage/List";
+import { BoardListContainer, TitleContainer } from "./styles";
+
+const BoardBody = ({ type }: { type: string }) => {
+  return (
+    <>
+      <TitleContainer>{type}</TitleContainer>
+      <BoardListContainer>
+        <BoardList type={type} />
+      </BoardListContainer>
+    </>
+  );
+};
+
+export default BoardBody;

--- a/Client/src/Components/Organisms/BoardBody/styles.tsx
+++ b/Client/src/Components/Organisms/BoardBody/styles.tsx
@@ -1,0 +1,15 @@
+import styled from "styled-components";
+
+const TitleContainer = styled.div`
+  text-align: center;
+  font-size: 32px;
+  padding: 30px 0 100px 0;
+`;
+
+const BoardListContainer = styled.div`
+  width: 100%;
+  background-color: #f5f5f5;
+  padding: 30px 0;
+`;
+
+export { TitleContainer, BoardListContainer };

--- a/Client/src/Components/Organisms/NoticeBody/index.tsx
+++ b/Client/src/Components/Organisms/NoticeBody/index.tsx
@@ -1,0 +1,5 @@
+const NoticeBody = () => {
+  return <div>1</div>;
+};
+
+export default NoticeBody;

--- a/Client/src/Components/Organisms/NoticeBody/index.tsx
+++ b/Client/src/Components/Organisms/NoticeBody/index.tsx
@@ -1,5 +1,0 @@
-const NoticeBody = () => {
-  return <div>1</div>;
-};
-
-export default NoticeBody;

--- a/Client/src/Components/Pages/Board.tsx
+++ b/Client/src/Components/Pages/Board.tsx
@@ -1,4 +1,4 @@
-const BoardPage = () => {
-  return <div>게시판 페이지입니다.</div>;
-};
+import BoardTemplate from "@Templates/Board";
+
+const BoardPage = () => <BoardTemplate />;
 export default BoardPage;

--- a/Client/src/Components/Pages/Notice.tsx
+++ b/Client/src/Components/Pages/Notice.tsx
@@ -1,5 +1,5 @@
-const NoticePage = () => {
-  return <div>공지사항 페이지</div>;
-};
+import NoticeTemplate from "@Templates/Notice";
+
+const NoticePage = () => <NoticeTemplate />;
 
 export default NoticePage;

--- a/Client/src/Components/Templates/Board/index.tsx
+++ b/Client/src/Components/Templates/Board/index.tsx
@@ -1,0 +1,18 @@
+import BoardBody from "@Organisms/BoardBody";
+import Header from "@Organisms/Header";
+import { withRouter } from "react-router-dom";
+import { History } from "history";
+
+const BoardTemplate = ({ history }: { history: History }) => {
+  const handleHeaderClick = () => {
+    history.push("/main");
+  };
+  return (
+    <>
+      <Header onClick={handleHeaderClick} />
+      <BoardBody type="자유게시판" />
+    </>
+  );
+};
+
+export default withRouter(BoardTemplate);

--- a/Client/src/Components/Templates/Notice/index.tsx
+++ b/Client/src/Components/Templates/Notice/index.tsx
@@ -1,0 +1,18 @@
+import Header from "@Organisms/Header";
+import { withRouter } from "react-router-dom";
+import { History } from "history";
+import NoticeBody from "@Organisms/NoticeBody";
+
+const NoticeTemplate = ({ history }: { history: History }) => {
+  const handleHeaderClick = () => {
+    history.push("/main");
+  };
+  return (
+    <>
+      <Header onClick={handleHeaderClick} />
+      <NoticeBody />
+    </>
+  );
+};
+
+export default withRouter(NoticeTemplate);

--- a/Client/src/Components/Templates/Notice/index.tsx
+++ b/Client/src/Components/Templates/Notice/index.tsx
@@ -1,7 +1,7 @@
 import Header from "@Organisms/Header";
 import { withRouter } from "react-router-dom";
 import { History } from "history";
-import NoticeBody from "@Organisms/NoticeBody";
+import BoardBody from "@Organisms/BoardBody";
 
 const NoticeTemplate = ({ history }: { history: History }) => {
   const handleHeaderClick = () => {
@@ -10,7 +10,7 @@ const NoticeTemplate = ({ history }: { history: History }) => {
   return (
     <>
       <Header onClick={handleHeaderClick} />
-      <NoticeBody />
+      <BoardBody type="공지사항" />
     </>
   );
 };

--- a/Client/src/Hook/test/index.ts
+++ b/Client/src/Hook/test/index.ts
@@ -34,6 +34,7 @@ export const useChangeCalendarView = (
   };
 
   useEffect(() => {
+    console.log("?");
     changeView();
   }, [calendarRef.current]);
 };

--- a/Client/src/Recoil/BoardContent/index.ts
+++ b/Client/src/Recoil/BoardContent/index.ts
@@ -1,4 +1,4 @@
-import { atom, selectorFamily } from "recoil";
+import { GetRecoilValue, selectorFamily } from "recoil";
 import { _API } from "@API/.";
 import { getBoardContents } from "@API/test";
 import {
@@ -16,4 +16,30 @@ export const BoardContentSelector = selectorFamily<
     const res = await _API({ api: getBoardContents, apiSrc });
     return res;
   },
+});
+
+export const GetBoardContentLengthSelector = selectorFamily<number, string>({
+  key: "GetBoardContentLengthSelector",
+  get:
+    (apiSrc: string) =>
+    async ({ get }: { get: GetRecoilValue }) => {
+      const list = get(BoardContentSelector(apiSrc));
+      return Math.ceil(list.length / 10);
+    },
+});
+export const BoardContentPagenationSelector = selectorFamily<
+  BoardContentType[] | RankingContentType[] | ProjectContentType[],
+  [number, string]
+>({
+  key: "BoardContentPagenationSelector",
+  get:
+    ([num, apiSrc]) =>
+    async ({ get }: { get: GetRecoilValue }) => {
+      const list = get(BoardContentSelector(apiSrc));
+      return list;
+      // return list.filter(
+      //   (item: BoardContentType | RankingContentType | ProjectContentType) =>
+      //     item.idx > num * 10 && item.idx <= (num + 1) * 10
+      // );
+    },
 });


### PR DESCRIPTION
[ 진행 작업 ]
- 공지사항 게시판, 자유게시판 구현

[ 문제 사항 ]
- 공지사항게시판을 최대한 로그인 후 메인페이지의 컴포넌트를 재사용하고싶었다.
- 공지사항게시판으로 자유게시판도 만들고 싶었다.

[ 해결 방법 ]
- 공지사항 => 자유게시판은 매우쉬웠다. ( 내 코드를 재사용해서 그런가? )
- 메인 => 공지사항은 은근 어려웠다. ( 한솔이 코드를 내가 재사용 )

---

추가로, 공지사항 및 자유게시판에서 글 목록 넘어가는 방법 js로 직접 구현하였다.
추가로, recoil select Family사용할때 get에서 에러가난다... 모든 비즈니스 로직을 리코일로 빼고싶다.