### PR TITLE
[ FE ] 과방 대여 페이지 반응형 디자인 (Phone)

### DIFF
--- a/Client/src/Components/Atoms/Input/styles.tsx
+++ b/Client/src/Components/Atoms/Input/styles.tsx
@@ -1,3 +1,4 @@
+import { TABLET_WIDTH } from "@Constant/.";
 import { BasicInputProps } from "@src/Common/Type";
 import { HoverPointer } from "@Style/.";
 import styled from "styled-components";
@@ -25,4 +26,8 @@ export const ReserveInput = styled.input<{ height: string; width: string }>`
   width: ${({ width }) => width};
   height: ${({ height }) => height};
   padding: 0 10px;
+  @media only screen and (max-width: ${TABLET_WIDTH}px) {
+    width: 150px;
+    height: 30px;
+  }
 `;

--- a/Client/src/Components/Molecules/ReserveForm/index.tsx
+++ b/Client/src/Components/Molecules/ReserveForm/index.tsx
@@ -10,6 +10,8 @@ import {
   ReservorContainer,
   SpliteTimeSpan,
   TimerContainer,
+  SpiltTimeSpanMobile,
+  SplitTimeSpanContainer,
 } from "./style";
 
 export const ReserveBoxHeader = () => (
@@ -77,12 +79,15 @@ export const ReserveInputForm = ({
           />
         </span>
         <SpliteTimeSpan>-</SpliteTimeSpan>
-        <ReserveInput
-          {...ReserveSmallInputType}
-          ref={eTimeRef}
-          placeholder="21:00"
-          type="text"
-        />
+        <SplitTimeSpanContainer>
+          <SpiltTimeSpanMobile>~</SpiltTimeSpanMobile>
+          <ReserveInput
+            {...ReserveSmallInputType}
+            ref={eTimeRef}
+            placeholder="21:00"
+            type="text"
+          />
+        </SplitTimeSpanContainer>
       </TimerContainer>
     </InputDataContainer>
   );

--- a/Client/src/Components/Molecules/ReserveForm/style.tsx
+++ b/Client/src/Components/Molecules/ReserveForm/style.tsx
@@ -1,3 +1,4 @@
+import { TABLET_WIDTH } from "@Constant/.";
 import { DefaultBorderColor, DefaultColor } from "@Style/.";
 import styled from "styled-components";
 
@@ -5,23 +6,37 @@ export const ReserveBoxTitle = styled.div`
   color: ${DefaultColor};
   border-bottom: 1px solid ${DefaultBorderColor};
   margin-bottom: 32px;
+  @media only screen and (max-width: ${TABLET_WIDTH}px) {
+    padding-bottom: 5px;
+    font-size: 22px;
+    font-weight: 500;
+  }
 `;
 
 export const ReservorContainer = styled.div`
   display: flex;
   align-items: center;
   margin-bottom: 10px;
+  @media only screen and (max-width: ${TABLET_WIDTH}px) {
+    justify-content: center;
+  }
 `;
 
 export const ReserveBoxText = styled.span`
   color: ${DefaultColor};
   font-size: 20px;
   margin-right: 15px;
+  @media only screen and (max-width: ${TABLET_WIDTH}px) {
+    font-size: 16px;
+  }
 `;
 
 export const InputDataContainer = styled.div`
   width: 90%;
   margin: auto;
+  @media only screen and (max-width: ${TABLET_WIDTH}px) {
+    width: 270px;
+  }
 `;
 
 export const DateContainer = styled.div`
@@ -32,6 +47,17 @@ export const DateContainer = styled.div`
   span {
     display: flex;
     align-items: center;
+    @media only screen and (max-width: ${TABLET_WIDTH}px) {
+      font-size: 15px;
+    }
+  }
+  @media only screen and (max-width: ${TABLET_WIDTH}px) {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    width: 270px;
+    height: 70px;
+    margin-bottom: 10px;
   }
 `;
 
@@ -39,10 +65,18 @@ export const TimerContainer = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  @media only screen and (max-width: ${TABLET_WIDTH}px) {
+    width: 270px;
+    flex-direction: column;
+    align-items: center;
+  }
 `;
 
 export const ReserveBoxSmallText = styled(ReserveBoxText)`
   font-size: 16px;
+  @media only screen and (max-width: ${TABLET_WIDTH}px) {
+    font-size: 15px;
+  }
 `;
 
 export const SpliteTimeSpan = styled.span`
@@ -50,6 +84,9 @@ export const SpliteTimeSpan = styled.span`
   font-size: 55px;
   display: flex;
   align-items: center;
+  @media only screen and (max-width: ${TABLET_WIDTH}px) {
+    display: none;
+  }
 `;
 
 export const ReserveSmallInputType = {
@@ -61,3 +98,24 @@ export const ReserveLargeInputType = {
   width: "190px",
   height: "40px",
 };
+
+export const SpiltTimeSpanMobile = styled.span`
+  display: none;
+  @media only screen and (max-width: ${TABLET_WIDTH}px) {
+    display: inline;
+    font-size: 20px;
+  }
+`;
+
+export const SplitTimeSpanContainer = styled.div`
+  @media only screen and (max-width: ${TABLET_WIDTH}px) {
+    display: flex;
+    justify-content: center;
+    width: 270px;
+    margin-top: 10px;
+    input {
+      margin-left: 15px;
+      margin-right: -16px;
+    }
+  }
+`;

--- a/Client/src/Components/Organisms/BoardBody/styles.tsx
+++ b/Client/src/Components/Organisms/BoardBody/styles.tsx
@@ -1,3 +1,4 @@
+import { TABLET_WIDTH } from "@Constant/.";
 import { DefaultColor } from "@Style/.";
 import styled from "styled-components";
 
@@ -6,6 +7,10 @@ const TitleContainer = styled.div`
   font-size: 32px;
   padding: 30px 0 50px 0;
   color: ${DefaultColor};
+  @media only screen and (max-width: ${TABLET_WIDTH}px) {
+    font-size: 25px;
+    padding: 20px 0 20px 0;
+  }
 `;
 
 const BoardListContainer = styled.div`

--- a/Client/src/Components/Organisms/Reserve/Body/styles.tsx
+++ b/Client/src/Components/Organisms/Reserve/Body/styles.tsx
@@ -7,6 +7,10 @@ export const ReserveCalendarContainer = styled.div`
   margin-right: 20px;
   min-width: 480px;
   position: relative;
+  @media only screen and (max-width: ${TABLET_WIDTH}px) {
+    min-width: 375px;
+    margin: 0;
+  }
 `;
 
 export const ReserveBodyContainer = styled(BoardListContainer)`
@@ -19,9 +23,10 @@ export const ReserveBoxContainer = styled.div`
   width: 40%;
   @media only screen and (max-width: ${TABLET_WIDTH}px) {
     position: fixed;
-    width: 500px;
+    width: 350px;
     top: auto;
     left: auto;
+    height: 470px;
   }
 `;
 
@@ -31,4 +36,10 @@ export const ToggleButtonContainer = styled.div`
   position: absolute;
   top: 10px;
   left: 50%;
+  @media only screen and (max-width: ${TABLET_WIDTH}px) {
+    width: 150px;
+    height: 30px;
+    top: 35px;
+    left: 55%;
+  }
 `;

--- a/Client/src/Components/Organisms/Reserve/ReserveBox/index.tsx
+++ b/Client/src/Components/Organisms/Reserve/ReserveBox/index.tsx
@@ -10,7 +10,11 @@ import { ReserveBoxText } from "@Molecules/ReserveForm/style";
 import { LoginButtonType } from "@Style/.";
 import { checkTablet } from "@Util/.";
 import { Dispatch, SetStateAction, useRef } from "react";
-import { ButtonContainer, ReserveBoxContainer } from "./styles";
+import {
+  ButtonContainer,
+  ReserveBoxContainer,
+  ReserveBoxTextContainer,
+} from "./styles";
 import { makeReservationRoomType } from "./util";
 
 const ReserveBox = ({
@@ -52,7 +56,9 @@ const ReserveBox = ({
     <ReserveBoxContainer>
       <ReserveBoxHeader />
       <ReserveBoxName nameRef={userNameRef} />
-      <ReserveBoxText>날짜</ReserveBoxText>
+      <ReserveBoxTextContainer>
+        <ReserveBoxText>날짜</ReserveBoxText>
+      </ReserveBoxTextContainer>
       <ReserveInputForm
         sDateRef={startDateRef}
         eDateRef={endDateRef}

--- a/Client/src/Components/Organisms/Reserve/ReserveBox/styles.tsx
+++ b/Client/src/Components/Organisms/Reserve/ReserveBox/styles.tsx
@@ -1,3 +1,4 @@
+import { TABLET_WIDTH } from "@Constant/.";
 import styled from "styled-components";
 
 export const ReserveBoxContainer = styled.div`
@@ -13,4 +14,19 @@ export const ButtonContainer = styled.div`
   margin: auto;
   width: 150px;
   height: 50px;
+  @media only screen and (max-width: ${TABLET_WIDTH}px) {
+    margin-top: 32px;
+  }
+`;
+
+export const ReserveBoxTextContainer = styled.div`
+  @media only screen and (max-width: ${TABLET_WIDTH}px) {
+    width: 270px;
+    text-align: center;
+    margin: 35px 0 15px 0;
+    span {
+      font-weight: 500;
+      font-size: 18px;
+    }
+  }
 `;

--- a/Client/src/Components/Organisms/Reserve/ReserveCalendar/styles.tsx
+++ b/Client/src/Components/Organisms/Reserve/ReserveCalendar/styles.tsx
@@ -1,3 +1,4 @@
+import { TABLET_WIDTH } from "@Constant/.";
 import { DefaultBorderColor, DefaultColor } from "@Style/.";
 import styled from "styled-components";
 
@@ -9,6 +10,9 @@ export const ReserveCalendarContainer = styled.div`
   border-radius: 21px;
   padding: 40px;
   min-width: 480px;
+  @media only screen and (max-width: ${TABLET_WIDTH}px) {
+    min-width: 375px;
+  }
 `;
 
 export const ReserveCalendarTitle = styled.p`


### PR DESCRIPTION
[진행 작업]
 과방 대여 페이지 Phone에 맞춰 반응형 레이아웃 추가
 
[문제 사항]
 기존 컴포넌트 구조 만으로 반응형 레이아웃을 만들기에 한계가 있었음

[해결 방법]
 컨테이너를 추가적으로 만들고 기본적으로 display none을 설정해서 데스크탑 레이아웃에는 영향이 가지 않도록 설정,
 max-width가 TABLET_WIDTH일 때 해당 스타일이 적용되도록 했음.