### PR TITLE
과방 대여 신청 내역 확인 모달창 작업, 스터디, 프로젝트 페이지 마감 콘텐츠의 신청 버튼 제거

### DIFF
--- a/Client/src/Components/Molecules/Board/BoardPreview/Card/collecting.tsx
+++ b/Client/src/Components/Molecules/Board/BoardPreview/Card/collecting.tsx
@@ -34,9 +34,13 @@ const CardBoardPreview = ({
         <Info>{`리더 : ${leaderName}`}</Info>
         <Info>{`인원 : ${numParticipant} / ${totalHeadcount}`}</Info>
       </CollectingInfoContainer>
-      <MobileApplyBtnContainer>
-        <ApplyButton {...ApplyButtonType()} />
-      </MobileApplyBtnContainer>
+      {STUDY_STATUS[status] === "마감" ? (
+        <MobileApplyBtnContainer />
+      ) : (
+        <MobileApplyBtnContainer>
+          <ApplyButton {...ApplyButtonType()} />
+        </MobileApplyBtnContainer>
+      )}
     </Container>
   );
 };

--- a/Client/src/Components/Organisms/Reserve/ReserveCalendar/Body/index.tsx
+++ b/Client/src/Components/Organisms/Reserve/ReserveCalendar/Body/index.tsx
@@ -1,6 +1,8 @@
 import { DAY_NAMES } from "@Constant/.";
+import useCloseModal from "@src/Hook/useCloseModal";
 import { reservationDatasProps } from "@Type/Reservation";
-import { Suspense, useState } from "react";
+import { Suspense, useRef, useState } from "react";
+import { isTemplateSpan } from "typescript";
 
 import { CalendarBodyProps } from "../Header";
 import ReserveModal from "../Modal";
@@ -10,7 +12,10 @@ import { checkReserve, getMonthDays, getReserveDatas } from "./util";
 const CalendarBody = ({ month, year, data }: CalendarBodyProps) => {
   const [toggle, setToggle] = useState<boolean>(false);
   const [reserveDate, setReserveDate] = useState<reservationDatasProps[]>([]);
-
+  const [order, setOrder] = useState<number>(0);
+  if (order > reserveDate.length - 1) {
+    setOrder(0);
+  }
   const handleDayClick = ({ target }: { target: any }) => {
     const day = target.getAttribute("data-day");
     if (!day) return;
@@ -58,9 +63,15 @@ const CalendarBody = ({ month, year, data }: CalendarBodyProps) => {
         </div>
         {toggle && (
           <div>
-            {reserveDate.map((item, idx) => (
+            <ReserveModal
+              items={reserveDate}
+              setToggle={setToggle}
+              order={order}
+              setOrder={setOrder}
+            />
+            {/* {reserveDate.map((item, idx) => (
               <ReserveModal key={idx} item={item} />
-            ))}
+            ))} */}
           </div>
         )}
       </>

--- a/Client/src/Components/Organisms/Reserve/ReserveCalendar/Modal/index.tsx
+++ b/Client/src/Components/Organisms/Reserve/ReserveCalendar/Modal/index.tsx
@@ -1,5 +1,83 @@
-const ReserveModal = ({ item }: { item: any }) => {
-  return <div>{JSON.stringify(item)}</div>;
+import useCloseModal from "@src/Hook/useCloseModal";
+import { useRef, useState } from "react";
+import {
+  Content,
+  ModalContainer,
+  ModalContent,
+  ModalContentFooter,
+  ModalContentHeader,
+  ModalSide,
+  ReserveDate,
+} from "./styles";
+
+const ReserveModal = ({
+  items,
+  order,
+  setToggle,
+  setOrder,
+}: {
+  items: any;
+  order: any;
+  setToggle: any;
+  setOrder: any;
+}) => {
+  if (order > items.length - 1) {
+    setOrder(0);
+  }
+  const item = items[order];
+
+  const handlePrevClick = () => {
+    if (order === 0) return;
+    setOrder(order - 1);
+  };
+  const handleNextClick = () => {
+    if (order === items.length - 1) return;
+    setOrder(order + 1);
+  };
+
+  const Ref = useRef<HTMLDivElement>(null);
+  const fn = () => setToggle(false);
+  useCloseModal({ ref: Ref, fn });
+
+  return (
+    // <ReserveModal item={item} setOrder={setOrder} />
+    <ModalContainer ref={Ref}>
+      <ModalSide>
+        <button className="ModalLeftButton" onClick={handlePrevClick}>
+          {"<"}
+        </button>
+        {/* <button className="ModalLeftButton">{"<"}</button> */}
+      </ModalSide>
+      <ModalContent>
+        <ModalContentHeader>
+          <span>Host : {item.host}</span>
+        </ModalContentHeader>
+        <Content>
+          <ReserveDate>
+            <span>예약 날짜</span>
+            <span>
+              {item.date} - {item.date}
+            </span>
+          </ReserveDate>
+          <ReserveDate>
+            <span>예약 시간</span>
+            <span>{item.hour}</span>
+          </ReserveDate>
+        </Content>
+        <ModalContentFooter>
+          <span>
+            {order + 1}/{items.length}
+          </span>
+        </ModalContentFooter>
+      </ModalContent>
+      <ModalSide>
+        {/* <button className="ModalLeftButton"> */}
+        <button className="ModalLeftButton" onClick={handleNextClick}>
+          {">"}
+        </button>
+      </ModalSide>
+    </ModalContainer>
+  );
 };
 
 export default ReserveModal;

--- a/Client/src/Components/Organisms/Reserve/ReserveCalendar/Modal/styles.tsx
+++ b/Client/src/Components/Organisms/Reserve/ReserveCalendar/Modal/styles.tsx
@@ -1,0 +1,79 @@
+import styled from "styled-components";
+
+export const ModalContainer = styled.div`
+  position: absolute;
+  top: 30%;
+  left: 29%;
+  width: 350px;
+  height: 300px;
+  z-index: 2;
+  background: #ffffff;
+  box-shadow: 0px 0px 14px #00000029;
+  border: 1px solid #ffffff;
+  border-radius: 37px;
+  display: flex;
+`;
+
+export const ModalContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 60%;
+  height: 100%;
+`;
+
+export const ModalSide = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 20%;
+  height: 100%;
+  button {
+    font-size: 23px;
+    color: #d8d8d8;
+  }
+`;
+
+export const ModalContentHeader = styled.div`
+  width: 100%;
+  height: 25%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  span {
+    color: #42556b;
+  }
+`;
+
+export const Content = styled.div`
+  width: 100%;
+  height: 55%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+`;
+
+export const ModalContentFooter = styled.div`
+  width: 100%;
+  height: 20%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  span {
+    color: #858585;
+  }
+`;
+
+export const ReserveDate = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  span {
+    margin-bottom: 14px;
+    color: #42556b;
+  }
+`;


### PR DESCRIPTION
[작업 내용]
1. 과방 대여 페이지 신청 내역 확인 모달창 구축.
2. 프로젝트 페이지 & 스터디 페이지 마감 콘텐츠에 있던 신청 버튼 삭제.

[개선점]
오늘 작업한 모달 창을 아직 디자인 패턴에 맞춰 분리하지 않음.
이후에 시간 여유 있을 때 분리할 예정.