### PR TITLE
메인 페이지 게시판 제목 크기 반응형에 맞게 수정, 과방 대여 모달 창 반응형 레이아웃 구현

### DIFF
--- a/Client/src/API/Account/index.ts
+++ b/Client/src/API/Account/index.ts
@@ -24,7 +24,6 @@ export const getCheckLogin = async () => {
 };
 export const postLoginInfo = async (body: LoginInfoType) => {
   const { data } = await axios.post(POST_LOGIN_INFO, body);
-  console.log(data);
   return data;
 };
 

--- a/Client/src/API/Account/index.ts
+++ b/Client/src/API/Account/index.ts
@@ -24,6 +24,7 @@ export const getCheckLogin = async () => {
 };
 export const postLoginInfo = async (body: LoginInfoType) => {
   const { data } = await axios.post(POST_LOGIN_INFO, body);
+  console.log(data);
   return data;
 };
 
@@ -37,7 +38,10 @@ export const postRequestMail = async (body: { email: string }) => {
   return data;
 };
 
-export const postCheckMail = async (body: { cacheKey: string; authNum: string }) => {
+export const postCheckMail = async (body: {
+  cacheKey: string;
+  authNum: string;
+}) => {
   const { data } = await axios.post(POST_CHECK_MAIL, body);
   return data;
 };

--- a/Client/src/Components/Molecules/Content/ContentTitle/style.tsx
+++ b/Client/src/Components/Molecules/Content/ContentTitle/style.tsx
@@ -1,4 +1,4 @@
-import { TABLET_WIDTH } from "@Constant/index";
+import { MOBILE_WIDTH, TABLET_WIDTH } from "@Constant/index";
 import { DefaultColor, AlignCenterBetween, textOverflowSafe } from "@Style/.";
 import styled from "styled-components";
 
@@ -23,7 +23,7 @@ export const Title = styled.p<Props>`
   font-size: ${({ type }) => (type === "small" ? "0.8rem" : "1.5rem")};
   font-weight: 700;
   ${textOverflowSafe};
-  @media only screen and (max-width: ${TABLET_WIDTH}px) {
+  @media only screen and (max-width: ${MOBILE_WIDTH}px) {
     font-size: 1.05rem;
   }
 `;

--- a/Client/src/Components/Organisms/Reserve/ReserveCalendar/Modal/styles.tsx
+++ b/Client/src/Components/Organisms/Reserve/ReserveCalendar/Modal/styles.tsx
@@ -1,3 +1,4 @@
+import { MOBILE_WIDTH } from "@Constant/.";
 import styled from "styled-components";
 
 export const ModalContainer = styled.div`
@@ -12,6 +13,11 @@ export const ModalContainer = styled.div`
   border: 1px solid #ffffff;
   border-radius: 37px;
   display: flex;
+  @media only screen and (max-width: ${MOBILE_WIDTH}px) {
+    width: 300px;
+    height: 250px;
+    left: 10%;
+  }
 `;
 
 export const ModalContent = styled.div`


### PR DESCRIPTION
[작업 내용]
1. 메인 페이지의 게시판 제목의 크기가 TABLET_WIDTH 기준으로 변해서 그리드 템플릿이 바뀌는 지점인 MOBILE_WIDTH 기준으로 바꿈
2. 과방 대여 모달 창 MOBILE_WIDTH에 맞춰서 레이아웃 추가